### PR TITLE
Adding common Apache log file location for FreeBSD

### DIFF
--- a/attack/lfi/common-unix-httpd-log-locations.txt
+++ b/attack/lfi/common-unix-httpd-log-locations.txt
@@ -28,3 +28,5 @@
 /var/log/apache2/error.log 
 /var/log/error_log 
 /var/log/error.log 
+/var/log/httpd-access.log
+/var/log/httpd-error.log


### PR DESCRIPTION
Adding the two paths below. Common Apache log file locations for FreeBSD

/var/log/httpd-access.log
/var/log/httpd-error.log