### PR TITLE
Update HTTP Response Splitting resources

### DIFF
--- a/attack/http-protocol/README.md
+++ b/attack/http-protocol/README.md
@@ -1,4 +1,3 @@
 References:
 
-http://ha.ckers.org/response-splitting.html
-
+https://web.archive.org/web/20150426090054/http://ha.ckers.org/response-splitting.html


### PR DESCRIPTION
- ha.ckers.org is out since 2015. replacing by archived URL.